### PR TITLE
SCDF2.x custom app don't reach deployed state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ hs_err_pid*
 .gradle/
 .idea/
 *.iml
+
+build/*
+out/**

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
-apply plugin: 'org.springframework.boot'
 
 group = 'com.example'
 version = '0.0.1'
@@ -25,12 +24,14 @@ repositories {
 	maven { url "https://repo.spring.io/milestone" }
 }
 
-ext['springCloudVersion'] = 'Greenwich.M3'
+ext['springCloudVersion'] = 'Greenwich.RC1'
 
 dependencies {
-	implementation('org.springframework.cloud:spring-cloud-stream')
+	compile('org.springframework.boot:spring-boot-starter')
+	compile('org.springframework.boot:spring-boot-starter-web')
+	compile('org.springframework.boot:spring-boot-starter-actuator')
 	implementation('org.springframework.cloud:spring-cloud-stream-binder-kafka')
-	implementation('org.springframework.kafka:spring-kafka')
+
 	compileOnly('org.projectlombok:lombok')
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	testImplementation('org.springframework.cloud:spring-cloud-stream-test-support')

--- a/build/resources/main/application.yml
+++ b/build/resources/main/application.yml
@@ -1,3 +1,0 @@
-spring.cloud.stream.bindings.output:
-  destination: default-random-data
-  contentType: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,2 @@
 spring.cloud.stream.bindings.output:
-  destination: default-random-data
   contentType: application/json


### PR DESCRIPTION
 - SCDF expects the Info and Health actuator endpoints for the app to be reachable therefore the org.springframework.boot:spring-boot-starter-web and org.springframework.boot:spring-boot-starter-actuator dependency are required

 - SCDF presumes that the app's output channel is `output`. Setting an custom channel name (e.g. spring.cloud.stream.bindings.output.destination=default-random-data) overrides this and require this. To create and deploy streams with different or multiple channels you should use the new SCDF application DSL: http://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/#spring-cloud-dataflow-stream-app-dsl

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2652